### PR TITLE
Implement #[serde(default = "..")] field attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ryu = "1.0"
 [dev-dependencies]
 automod = "1.0"
 rustversion = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 trybuild = { version = "1.0.49", features = ["diff"] }

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -22,7 +22,7 @@ enum Variant<'a> {
     Named {
         name: &'a Ident,
         fields: Fields<'a>,
-        attrs: DataAttrs,
+        // attrs: DataAttrs,
     },
 }
 
@@ -45,17 +45,14 @@ impl<'a> Variant<'a> {
             Variant::Named {
                 name,
                 fields,
-                attrs,
+                // attrs,
             } => {
                 let name_str = str_name(name.to_string(), rename_all, None);
                 let field_impls = fields.iter().map(|f| {
                     let ident = f.field_name;
                     // TODO: handle rename all
-                    let name = str_name(
-                        f.field_name.to_string(),
-                        attrs.rename_all.as_ref(),
-                        f.attrs.rename.as_deref(),
-                    );
+                    let name = str_name(f.field_name.to_string(), None, f.attrs.rename.as_deref());
+
                     quote! {
                         let mut #ident = jayson::__private::None;
                         let v = jayson::Jayson::begin(&mut #ident);
@@ -95,12 +92,15 @@ impl<'a> DerivedEnum<'a> {
                 syn::Fields::Named(ref named) => {
                     let name = &variant.ident;
                     let fields = Fields::parse(named)?;
-                    let attrs = DataAttrs::parse(&variant.attrs, false)?;
+                    // TODO: this cannot be correct?
+                    // the attributes for an enum variant are different than the attributes
+                    // for the whole enum/struct
+                    // let attrs = DataAttrs::parse(&variant.attrs, false)?;
 
                     Variant::Named {
                         name,
                         fields,
-                        attrs,
+                        // attrs,
                     }
                 }
                 syn::Fields::Unit => {

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -36,11 +36,7 @@ impl<'a> Variant<'a> {
                     }
                 })
             }
-            Variant::Named {
-                name,
-                fields,
-                // attrs,
-            } => {
+            Variant::Named { name, fields, .. } => {
                 let name_str = str_name(name.to_string(), rename_all, None);
                 let field_defaults = fields.iter().map(|f| {
                     if let Some(default) = &f.attrs.default {

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -16,14 +16,8 @@ pub struct DerivedEnum<'a> {
 
 #[derive(Debug)]
 enum Variant<'a> {
-    Unit {
-        name: &'a Ident,
-    },
-    Named {
-        name: &'a Ident,
-        fields: Fields<'a>,
-        // attrs: DataAttrs,
-    },
+    Unit { name: &'a Ident },
+    Named { name: &'a Ident, fields: Fields<'a> },
 }
 
 impl<'a> Variant<'a> {
@@ -48,21 +42,30 @@ impl<'a> Variant<'a> {
                 // attrs,
             } => {
                 let name_str = str_name(name.to_string(), rename_all, None);
+                let field_defaults = fields.iter().map(|f| {
+                    if let Some(default) = &f.attrs.default {
+                        let default = str::parse::<proc_macro2::TokenStream>(default).unwrap();
+                        quote! {
+                            jayson::__private::Option::Some(#default ())
+                        }
+                    } else {
+                        quote! {
+                            jayson::Jayson::<#err_ty>::default()
+                        }
+                    }
+                });
                 let field_impls = fields.iter().map(|f| {
                     let ident = f.field_name;
-                    // TODO: handle rename all
                     let name = str_name(f.field_name.to_string(), None, f.attrs.rename.as_deref());
 
                     quote! {
                         let mut #ident = jayson::__private::None;
                         let v = jayson::Jayson::begin(&mut #ident);
-                        let val = std::mem::replace(
-                            self.object
-                                .get_mut(#name)
-                                .ok_or_else(|| #err_ty::missing_field(#name))?,
-                            jayson::json::Value::Null,
-                        );
-                        jayson::__private::apply_object_to_visitor(v, val)?;
+
+                        if let jayson::__private::Option::Some(val) = self.object.get_mut(#name) {
+                            let val = std::mem::replace(val, jayson::json::Value::Null);
+                            jayson::__private::apply_object_to_visitor(v, val)?;
+                        }
                     }
                 });
 
@@ -72,7 +75,9 @@ impl<'a> Variant<'a> {
                         #(#field_impls)*
                         self.__out.replace(#enum_ident::#name {
                             #(
-                                #field_names: #field_names.unwrap(),
+                                #field_names: #field_names
+                                    .or_else(|| #field_defaults)
+                                    .ok_or_else(|| #err_ty::missing_field(#name_str))?,
                             )*
                         });
                     }
@@ -92,16 +97,7 @@ impl<'a> DerivedEnum<'a> {
                 syn::Fields::Named(ref named) => {
                     let name = &variant.ident;
                     let fields = Fields::parse(named)?;
-                    // TODO: this cannot be correct?
-                    // the attributes for an enum variant are different than the attributes
-                    // for the whole enum/struct
-                    // let attrs = DataAttrs::parse(&variant.attrs, false)?;
-
-                    Variant::Named {
-                        name,
-                        fields,
-                        // attrs,
-                    }
+                    Variant::Named { name, fields }
                 }
                 syn::Fields::Unit => {
                     let name = &variant.ident;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -282,12 +282,7 @@ impl DataAttrs {
                                                 nested.span(),
                                                 "Unexpected attribute",
                                             ))
-                                        } // _ => {
-                                          //     return Err(Error::new(
-                                          //         nested.span(),
-                                          //         "Unexpected attribute",
-                                          //     ))
-                                          // }
+                                        }
                                     }
                                 }
                                 syn::NestedMeta::Lit(lit) => {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -149,11 +149,15 @@ fn str_name(name: String, rename_all: Option<&RenameAll>, rename: Option<&str>) 
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 enum TagType {
     Internal(String),
-    #[default]
     External,
+}
+impl Default for TagType {
+    fn default() -> Self {
+        Self::External
+    }
 }
 
 #[derive(Default, Debug)]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,4 +1,3 @@
-mod deser_tagged;
 mod impls;
 
 use crate::error::Error;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -11,14 +11,14 @@ pub trait Jayson<E = Error>: Sized {
     ///
     /// ```rust
     /// # use jayson::make_place;
-    /// # use jayson::de::{Deserialize, Visitor};
+    /// # use jayson::de::{Jayson, Visitor, VisitorError};
     /// #
     /// # make_place!(Place);
     /// # struct S;
-    /// # impl Visitor for Place<S> {}
+    /// # impl<E: VisitorError> Visitor<E> for Place<S> {}
     /// #
-    /// # impl Deserialize for S {
-    /// fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+    /// # impl<E: VisitorError> Jayson<E> for S {
+    /// fn begin(out: &mut Option<Self>) -> &mut dyn Visitor<E> {
     ///     Place::new(out)
     /// }
     /// # }

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -10,9 +10,11 @@ use std::fmt::LowerHex;
 /// Deserialize a JSON string into any deserializable type.
 ///
 /// ```rust
-/// use jayson::{json, Deserialize};
+/// use jayson::{json, Jayson, Error};
+/// use jayson::de::VisitorError;
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(Jayson, Debug)]
+/// #[jayson(error = "Error")]
 /// struct Example {
 ///     code: u32,
 ///     message: String,

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -23,6 +23,22 @@ struct Nested {
     z: Option<String>,
 }
 
+#[derive(PartialEq, Debug, Jayson)]
+#[jayson(error = "Error")]
+struct StructWithDefaultAttr {
+    x: bool,
+    #[serde(default = "create_default_u8")]
+    y: u8,
+    #[jayson(default = "create_default_option_string")]
+    z: Option<String>,
+}
+fn create_default_u8() -> u8 {
+    1
+}
+fn create_default_option_string() -> Option<String> {
+    Some("helllo".to_owned())
+}
+
 #[test]
 fn test_de() {
     let j = r#" {"x": "X", "t1": { "sometag": "A" }, "t2": { "sometag": "B" }, "n": {"y": ["Y", "Y"]}} "#;
@@ -35,6 +51,34 @@ fn test_de() {
             y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
             z: None,
         }),
+    };
+    assert_eq!(actual, expected);
+
+    let j = r#"{
+            "x": true,
+            "y": 10
+        }
+        "#;
+    let actual: StructWithDefaultAttr = json::from_str(j).unwrap();
+    let expected = StructWithDefaultAttr {
+        x: true,
+        y: 10,
+        z: create_default_option_string(),
+    };
+    assert_eq!(actual, expected);
+
+    assert_eq!(actual, expected);
+
+    let j = r#"{
+            "x": true,
+            "z": null
+        }
+        "#;
+    let actual: StructWithDefaultAttr = json::from_str(j).unwrap();
+    let expected = StructWithDefaultAttr {
+        x: true,
+        y: 1,
+        z: None,
     };
     assert_eq!(actual, expected);
 }

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -1,10 +1,9 @@
 use jayson::{de::VisitorError, json, Error, Jayson};
 
 #[derive(PartialEq, Debug, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = "Error", tag = "sometag")]
 enum Tag {
     A,
-    #[jayson(rename = "renamedB")]
     B,
 }
 
@@ -26,7 +25,7 @@ struct Nested {
 
 #[test]
 fn test_de() {
-    let j = r#" {"x": "X", "t1": "A", "t2": "renamedB", "n": {"y": ["Y", "Y"]}} "#;
+    let j = r#" {"x": "X", "t1": { "sometag": "A" }, "t2": { "sometag": "B" }, "n": {"y": ["Y", "Y"]}} "#;
     let actual: Example = json::from_str(j).unwrap();
     let expected = Example {
         x: "X".to_owned(),


### PR DESCRIPTION
I have cleaned up the project a tiny bit by fixing a compilation error and failing tests. I also removed some code related to custom attributes on enum variants, which were not yet fully implemented (I will reintroduce them later).

The core of the PR is the implementation of the `#[serde(default = "some_function")]` attribute on struct and enum fields. 
This attribute initialises the field by calling the provided function in case the field's key was not found, which is how `serde_derive` works as well. So the exact same syntax is used, but it is also allowed to write `#[jayson(default = "some_function")]`

I have added some tests, including ones that compare the result of the deserialisation with `serde_json`, to ensure that they are consistent. In the process, I fixed a mistake in the handling of Optional fields in enum variants. See the details below:
<details>
Before, for this enum:
```rust
enum X {
    A { y: Option<bool> }
}
```
The following Json would fail to deserialise:
```json
{
    "tag": "A"
}
```
It now works as expected. The result is 
```rust
X::A { y: None }
```
</details>