### PR TITLE
Jayson trait implementations for BTreeSet, HashSet, serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ rust-version = "1.36"
 itoa = "1.0"
 jayson-internal = { version = "=0.1.0", path = "derive" }
 ryu = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 automod = "1.0"
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
-serde_json = "1.0"
 trybuild = { version = "1.0.49", features = ["diff"] }
 
 [workspace]


### PR DESCRIPTION
Make `BTreeSet`, `HashSet`, and `serde_json::Value` conform to `Jayson<E>`.

These types are used in the Meilisearch code base for the search query route. 
Admittedly, it would be best to avoid depending on `serde_json` in Jayson. But it would be more difficult to change  instances of `serde_json::Value` to `jayson::Value` there rather than adding this implementation. Eventually, it should go away.