### PR TITLE
Rewrite attribute parser to allow more varied arguments

### DIFF
--- a/derive/src/attribute_parser.rs
+++ b/derive/src/attribute_parser.rs
@@ -1,0 +1,213 @@
+use proc_macro2::Ident;
+use syn::{parenthesized, parse::ParseStream, parse2, Attribute, Expr, LitStr, Token};
+
+#[derive(Debug)]
+pub enum JaysonDefaultFieldAttribute {
+    DefaultTrait,
+    Function(Expr),
+}
+
+#[derive(Default, Debug)]
+pub struct JaysonFieldAttributes {
+    pub rename: Option<Ident>,
+    pub default: Option<JaysonDefaultFieldAttribute>,
+}
+
+impl JaysonFieldAttributes {
+    fn overwrite(&mut self, other: JaysonFieldAttributes) {
+        if let Some(rename) = other.rename {
+            self.rename = Some(rename)
+        }
+        if let Some(default) = other.default {
+            self.default = Some(default)
+        }
+    }
+}
+
+impl syn::parse::Parse for JaysonFieldAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut this = JaysonFieldAttributes::default();
+        // parse starting right after #[jayson .... ]
+        // so first get the content inside the parentheses
+
+        let content;
+        let _ = parenthesized!(content in input);
+        let input = content;
+        // consumed input: #[jayson( .... )]
+
+        loop {
+            let attr_name = input.parse::<Ident>()?;
+            // consumed input: #[jayson( ... attr_name ... )]
+            match attr_name.to_string().as_str() {
+                "rename" => {
+                    let _eq = input.parse::<Token![=]>()?;
+                    let ident = input.parse::<Ident>()?;
+                    // #[jayson( ... rename = ident )]
+                    this.rename = Some(ident);
+                }
+                "default" => {
+                    if input.peek(Token![=]) {
+                        let _eq = input.parse::<Token![=]>()?;
+                        let expr = input.parse::<Expr>()?;
+                        // #[jayson( ... default = expr )]
+                        this.default = Some(JaysonDefaultFieldAttribute::Function(expr));
+                    } else {
+                        this.default = Some(JaysonDefaultFieldAttribute::DefaultTrait);
+                    }
+                }
+                _ => {
+                    let message = format!("Unknown jayson attribute: {}", attr_name);
+                    return Result::Err(syn::Error::new_spanned(attr_name, message));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                let _comma = input.parse::<Token![,]>()?;
+                if input.is_empty() {
+                    break;
+                }
+                continue;
+            } else if input.is_empty() {
+                break;
+            } else {
+                // TODO: error message here
+                break;
+            }
+        }
+        Ok(this)
+    }
+}
+
+pub fn read_jayson_field_attributes(
+    attributes: &[Attribute],
+) -> Result<JaysonFieldAttributes, syn::Error> {
+    let mut this = JaysonFieldAttributes::default();
+    for attribute in attributes {
+        if let Some(ident) = attribute.path.get_ident() {
+            if ident != "jayson" {
+                continue;
+            }
+            let other = parse2::<JaysonFieldAttributes>(attribute.tokens.clone())?;
+            this.overwrite(other);
+        } else {
+            continue;
+        }
+    }
+    Ok(this)
+}
+
+#[derive(Debug)]
+pub enum RenameAll {
+    CamelCase,
+    LowerCase,
+}
+#[derive(Debug)]
+pub enum TagType {
+    Internal(String),
+    External,
+}
+impl Default for TagType {
+    fn default() -> Self {
+        Self::External
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct JaysonDataAttributes {
+    pub rename_all: Option<RenameAll>,
+    pub err_ty: Option<syn::Type>,
+    pub tag: TagType,
+}
+impl JaysonDataAttributes {
+    fn overwrite(&mut self, other: Self) {
+        if let Some(rename) = other.rename_all {
+            self.rename_all = Some(rename)
+        }
+        if let Some(err_ty) = other.err_ty {
+            self.err_ty = Some(err_ty)
+        }
+        if let TagType::Internal(x) = other.tag {
+            self.tag = TagType::Internal(x)
+        }
+    }
+}
+impl syn::parse::Parse for JaysonDataAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut this = JaysonDataAttributes::default();
+        // parse starting right after #[jayson .... ]
+        // so first get the content inside the parentheses
+
+        let content;
+        let _ = parenthesized!(content in input);
+        let input = content;
+        // consumed input: #[jayson( .... )]
+
+        loop {
+            let attr_name = input.parse::<Ident>()?;
+            // consumed input: #[jayson( ... attr_name ... )]
+            match attr_name.to_string().as_str() {
+                "rename_all" => {
+                    let _eq = input.parse::<Token![=]>()?;
+                    let ident = input.parse::<Ident>()?;
+                    // #[jayson( ... rename_all = ident )]
+                    let rename_all = match ident.to_string().as_str() {
+                        "camelCase" => RenameAll::CamelCase,
+                        "lowercase" => RenameAll::LowerCase,
+                        _ => {
+                            todo!("return good error message")
+                        }
+                    };
+                    this.rename_all = Some(rename_all);
+                }
+                "tag" => {
+                    let _eq = input.parse::<Token![=]>()?;
+                    let lit = input.parse::<LitStr>()?;
+                    // #[jayson( ... tag = "lit" )]
+                    this.tag = TagType::Internal(lit.value());
+                }
+                "error" => {
+                    let _eq = input.parse::<Token![=]>()?;
+                    let err_ty = input.parse::<syn::Type>()?;
+                    // #[jayson( ... error = err_ty )]
+                    this.err_ty = Some(err_ty);
+                }
+                _ => {
+                    let message = format!("Unknown jayson attribute: {}", attr_name);
+                    return Result::Err(syn::Error::new_spanned(attr_name, message));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                let _comma = input.parse::<Token![,]>()?;
+                if input.is_empty() {
+                    break;
+                }
+                continue;
+            } else if input.is_empty() {
+                break;
+            } else {
+                // TODO: error message here
+                break;
+            }
+        }
+        Ok(this)
+    }
+}
+
+pub fn read_jayson_data_attributes(
+    attributes: &[Attribute],
+) -> Result<JaysonDataAttributes, syn::Error> {
+    let mut this = JaysonDataAttributes::default();
+    for attribute in attributes {
+        if let Some(ident) = attribute.path.get_ident() {
+            if ident != "jayson" {
+                continue;
+            }
+            let other = parse2::<JaysonDataAttributes>(attribute.tokens.clone())?;
+            this.overwrite(other);
+        } else {
+            continue;
+        }
+    }
+    Ok(this)
+}

--- a/derive/src/attribute_parser.rs
+++ b/derive/src/attribute_parser.rs
@@ -9,7 +9,7 @@ pub enum JaysonDefaultFieldAttribute {
 
 #[derive(Default, Debug)]
 pub struct JaysonFieldAttributes {
-    pub rename: Option<Ident>,
+    pub rename: Option<LitStr>,
     pub default: Option<JaysonDefaultFieldAttribute>,
 }
 
@@ -41,7 +41,7 @@ impl syn::parse::Parse for JaysonFieldAttributes {
             match attr_name.to_string().as_str() {
                 "rename" => {
                     let _eq = input.parse::<Token![=]>()?;
-                    let ident = input.parse::<Ident>()?;
+                    let ident = input.parse::<LitStr>()?;
                     // #[jayson( ... rename = ident )]
                     this.rename = Some(ident);
                 }

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -19,6 +19,8 @@ pub struct DerivedStruct<'a> {
 impl<'a> DerivedStruct<'a> {
     pub fn parse(input: &'a DeriveInput, fields: &'a FieldsNamed) -> syn::Result<Self> {
         let attrs = read_jayson_data_attributes(&input.attrs)?;
+        // TODO: error message if "tag" is present
+
         let fields = Fields::parse(fields)?;
         let name = &input.ident;
         let generics = &input.generics;
@@ -62,7 +64,7 @@ impl<'a> DerivedStruct<'a> {
             .fields
             .iter()
             .map(|f| {
-                let renamed = f.attrs.rename.as_ref().map(|i| i.to_string());
+                let renamed = f.attrs.rename.as_ref().map(|i| i.value());
                 str_name(
                     f.field_name.to_string(),
                     self.attrs.rename_all.as_ref(),
@@ -137,7 +139,7 @@ impl<'a> DerivedStruct<'a> {
 
                     fn finish(&mut self) -> jayson::__private::Result<(), #err_ty> {
                         #(
-                            let #fieldname = self.#fieldname.take().ok_or(#err_ty::missing_field(#fieldstr))?;
+                            let #fieldname = self.#fieldname.take().ok_or(<#err_ty as jayson::de::VisitorError>::missing_field(#fieldstr))?;
                         )*
                         *self.__out = jayson::__private::Some(#ident {
                             #(

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -14,7 +14,7 @@ use std::fmt::LowerHex;
 /// use jayson::de::VisitorError;
 ///
 /// #[derive(Jayson, Debug)]
-/// #[jayson(error = "Error")]
+/// #[jayson(error = Error)]
 /// struct Example {
 ///     code: u32,
 ///     message: String,

--- a/tests/regression/issue24.rs
+++ b/tests/regression/issue24.rs
@@ -1,7 +1,7 @@
 use jayson::{de::VisitorError, json, Error, Jayson};
 
 #[derive(Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error)]
 pub struct Point {
     pub x: u32,
     pub y: u32,

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -3,14 +3,14 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
 #[serde(tag = "sometag")]
-#[jayson(error = "Error", tag = "sometag")]
+#[jayson(error = Error, tag = "sometag")]
 enum Tag {
     A,
     B,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error)]
 struct Example {
     x: String,
     t1: Tag,
@@ -19,19 +19,21 @@ struct Example {
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error)]
 struct Nested {
     y: Option<Vec<String>>,
     z: Option<String>,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error)]
 struct StructWithDefaultAttr {
     x: bool,
     #[serde(default = "create_default_u8")]
+    #[jayson(default = create_default_u8())]
     y: u8,
     #[serde(default = "create_default_option_string")]
+    #[jayson(default = create_default_option_string())]
     z: Option<String>,
 }
 fn create_default_u8() -> u8 {
@@ -43,40 +45,51 @@ fn create_default_option_string() -> Option<String> {
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
 #[serde(tag = "t")]
-#[jayson(error = "Error", tag = "t")]
+#[jayson(error = Error, tag = "t")]
 enum EnumWithOptionData {
     A {
         x: Option<u8>,
     },
     B {
         #[serde(default = "create_default_option_string")]
+        #[jayson(default = create_default_option_string())]
         x: Option<String>,
         #[serde(default = "create_default_u8")]
+        #[jayson(default = create_default_u8())]
         y: u8,
     },
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error, rename_all = camelCase)]
 #[serde(rename_all = "camelCase")]
 struct RenamedAllCamelCaseStruct {
     renamed_field: bool,
 }
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error, rename_all = lowercase)]
 #[serde(rename_all = "lowercase")]
 struct RenamedAllLowerCaseStruct {
     renamed_field: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
-#[jayson(error = "Error")]
+#[jayson(error = Error, tag = "t", rename_all = camelCase)]
 #[serde(tag = "t")]
 #[serde(rename_all = "camelCase")]
 enum RenamedAllCamelCaseEnum {
     SomeField { my_field: bool },
 }
 
+#[derive(PartialEq, Debug, Serialize, Deserialize, Jayson)]
+#[jayson(error = Error)]
+struct StructWithRenamedField {
+    #[jayson(rename = renamed_field)]
+    #[serde(rename = "renamed_field")]
+    x: bool,
+}
+
+#[track_caller]
 fn compare_with_serde_roundtrip<T>(x: T)
 where
     T: Serialize + Jayson + PartialEq + std::fmt::Debug,
@@ -156,4 +169,6 @@ fn test_de() {
         }
         "#,
     );
+
+    compare_with_serde_roundtrip(StructWithRenamedField { x: true });
 }


### PR DESCRIPTION
Currently, the `#[jayson(...)]` attributes are parsed to a `syn::Meta`. This means the only kind of syntax allowed within the attribute is:
```rust
#[jayson(name = "string_literal")]
#[jayson(path)]
#[jayson(name = "string_literal", path)]
```
But I'd like to:
1. not write identifiers, functions, modules, etc. as string literals, because they are fundamentally not string literals.
2. allow more complex syntax in the future, such as (for illustration purposes, I don't plan on implementing these particular syntaxes):
```rust
struct S {
	#[jayson(map(from: String, with: parse_datetime))]
	x: DateTime
	#[jayson(validate_with { y > 2 } else YMustBeSmallerThan2)]
	y: u8,
}
```
3. be able to write better error messages at parsing time

This is all done in this PR by writing a `syn::Parse` trait implementation for the data types that represent the Jayson parsed attributes.